### PR TITLE
Update broker config as list

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Kafka struct {
-	Brokers                     string        `yaml:"brokers"`
+	Brokers                     []string      `yaml:"brokers"`
 	Topic                       string        `yaml:"topic"`
 	ProducerBatchSize           int           `yaml:"producerBatchSize"`
 	ProducerBatchTickerDuration time.Duration `yaml:"producerBatchTickerDuration"`

--- a/example/config.yml
+++ b/example/config.yml
@@ -26,7 +26,9 @@ metric:
   path: /metrics
 kafka:
   topic: "topicname"
-  brokers: "broker1,broker2"
+  brokers:
+    - broker1
+    - broker2
   readTimeout: 30s
   writeTimeout: 30s
   producerBatchSize: 50

--- a/example/main.go
+++ b/example/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	gokafkaconnectcouchbase "github.com/Trendyol/go-kafka-connect-couchbase"
 	"github.com/Trendyol/go-kafka-connect-couchbase/couchbase"
 	"github.com/Trendyol/go-kafka-connect-couchbase/kafka"
 )
@@ -15,7 +16,7 @@ func mapper(event *couchbase.Event) *kafka.Message {
 }
 
 func main() {
-	connector := godcpkafkaconnector.NewConnector("./example/config.yml", mapper)
+	connector := gokafkaconnectcouchbase.NewConnector("./example/config.yml", mapper)
 
 	defer connector.Close()
 

--- a/kafka/producer/producer.go
+++ b/kafka/producer/producer.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"context"
 	"math"
-	"strings"
 	"time"
 
 	"github.com/Trendyol/go-kafka-connect-couchbase/config"
@@ -24,7 +23,7 @@ type producer struct {
 func NewProducer(config *config.Kafka, logger logger.Logger, errorLogger logger.Logger) Producer {
 	writer := &kafka.Writer{
 		Topic:        config.Topic,
-		Addr:         kafka.TCP(strings.Split(config.Brokers, ",")...),
+		Addr:         kafka.TCP(config.Brokers...),
 		Balancer:     &kafka.Hash{},
 		MaxAttempts:  math.MaxInt,
 		ReadTimeout:  config.ReadTimeout,


### PR DESCRIPTION
Instead of getting the list of brokers as a string, we need to be able to give it as a list.

Example:
```
brokers:
    - broker1
    - broker2
```

Solving https://github.com/Trendyol/go-kafka-connect-couchbase/issues/2 