### PR TITLE
fix: add transport to kafka writer

### DIFF
--- a/kafka/client.go
+++ b/kafka/client.go
@@ -183,6 +183,7 @@ func (c *client) Producer() *kafka.Writer {
 		Logger:       c.logger,
 		ErrorLogger:  c.errorLogger,
 		Compression:  kafka.Compression(c.config.GetCompression()),
+		Transport:    c.kafkaClient.Transport,
 	}
 }
 


### PR DESCRIPTION
We need to add transport to kafka writer to be able to use secure connection