### PR TITLE
feat: introduce kafka latency

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"time"
 
+	"github.com/Trendyol/go-dcp-client/helpers"
 	"github.com/Trendyol/go-dcp-client/logger"
 
 	"github.com/gookit/config/v2"
@@ -33,7 +34,8 @@ func (k *Kafka) GetCompression() int8 {
 }
 
 type Config struct {
-	Kafka *Kafka `yaml:"kafka"`
+	Kafka  *Kafka               `yaml:"kafka"`
+	Metric helpers.ConfigMetric `yaml:"metric"`
 }
 
 func Options(opts *config.Options) {

--- a/metric/collector.go
+++ b/metric/collector.go
@@ -1,0 +1,41 @@
+package metric
+
+import (
+	"github.com/Trendyol/go-dcp-client/helpers"
+	"github.com/Trendyol/go-kafka-connect-couchbase/kafka/producer"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Collector struct {
+	producer producer.Producer
+
+	dcpLatency *prometheus.Desc
+}
+
+func (s *Collector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(s, ch)
+}
+
+func (s *Collector) Collect(ch chan<- prometheus.Metric) {
+	producerMetric := s.producer.GetMetric()
+
+	ch <- prometheus.MustNewConstMetric(
+		s.dcpLatency,
+		prometheus.GaugeValue,
+		producerMetric.KafkaConnectorLatency.Value(),
+		[]string{}...,
+	)
+}
+
+func NewMetricCollector(producer producer.Producer) *Collector {
+	return &Collector{
+		producer: producer,
+
+		dcpLatency: prometheus.NewDesc(
+			prometheus.BuildFQName(helpers.Name, "kafka_connector_latency_ms", "current"),
+			"Kafka connector latency ms at 10sec windows",
+			[]string{},
+			nil,
+		),
+	}
+}


### PR DESCRIPTION
instead of adding latency here [^1]. we can iterate over messages added while flushing. what do you think?

[^1]: https://github.com/Trendyol/go-kafka-connect-couchbase/pull/39/files#diff-193d5e67a697138353d5cef343ffb0f1aefb4493dc6c972e5c2f687e9b7f22b3R76